### PR TITLE
Add MIT license to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "bit-mx/cache-entities",
     "description": "Creates cacheable entities",
     "type": "library",
+    "license": "MIT",
     "autoload": {
         "psr-4": {
             "BitMx\\CacheEntities\\": "src/"


### PR DESCRIPTION
The composer.json file has been updated to clarify that the library is licensed under MIT. This provides important licensing information to developers who might incorporate it into their projects.
