### PR TITLE
Implements cache memoization

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 7
+    level: 9
     paths:
         - src
     checkOctaneCompatibility: true
@@ -8,3 +8,8 @@ parameters:
         return: 100
         param: 100
         property: 100
+
+    ignoreErrors:
+            -
+                message: '#Call to an undefined method Illuminate\\Contracts\\Cache\\Repository::memo\(\)\.#'
+                path: src/Traits/HasCacheMethods.php

--- a/src/CacheEntity.php
+++ b/src/CacheEntity.php
@@ -29,4 +29,14 @@ abstract class CacheEntity implements CacheableEntity
     {
         return now()->addHour();
     }
+
+    protected function hasMemoization(): bool
+    {
+        return false;
+    }
+
+    protected function resolveCacheStore(): ?string
+    {
+        return null;
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BitMx\CacheEntities\Tests;
 
 use BitMx\CacheEntities\CacheEntitiesServiceProvider;
+use Illuminate\Cache\CacheServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 abstract class TestCase extends Orchestra
@@ -15,6 +16,7 @@ abstract class TestCase extends Orchestra
     protected function getPackageProviders($app): array
     {
         return [
+            CacheServiceProvider::class,
             CacheEntitiesServiceProvider::class,
         ];
     }


### PR DESCRIPTION
Adds the ability to memoize cached values, reducing the number of times values are resolved.

Introduces a `hasMemoization` method in the `CacheEntity` class to determine whether to use memoization.

Refactors the `HasCacheMethods` trait to use the `memo` method of the cache driver when `hasMemoization` returns `true`.

Increases phpstan level to 9 for improved code quality.
