### PR TITLE
Add `HasMemoization` trait with tests and documentation

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -26,5 +26,5 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
       - name: Run phpstan
-        run: vendor/bin/phpstan analyse  -c phpstan.dist.neon src --error-format=github
+        run: vendor/bin/phpstan analyse  -c phpstan.dist.neon --error-format=github
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Table of Contents
 
 * [Introduction](#introduction)
 * [Installation](#installation)
-* [Setup](#setup)
 * [Compatibility](#compatibility)
 * [Getting Started](#getting-started)
   * [Create a Cache Entity class](#create-a-cache-entity-class)
@@ -17,6 +16,7 @@ Table of Contents
   * [exists](#exists)
   * [doesNotExist](#doesnotexist)
   * [forget](#forget)
+* [Memoization](#memoization)
 
 
 
@@ -80,7 +80,7 @@ class CurrentUserCache extends CacheEntity
 You can use the artisan command to create a new Cache Entity:
 
 ```bash
-php artisan make:cache-entity CurrentUserCacheEntity
+php artisan make:cache-entity CurrentUserCache
 ```
 
 This command will create a new Cache Entity in the `app/cacheEntities` directory.
@@ -111,9 +111,9 @@ class CurrentUserCache extends CacheEntity
 To get the cached value, you can use the get method.
 
 ```php
-use App\CacheEntities\CurrentUserCacheEntity;
+use App\CacheEntities\CurrentUserCache;
 
-$cacheEntity = new CurrentUserCacheEntity(1);
+$cacheEntity = new CurrentUserCache(1);
 
 $user = $cacheEntity->get();
 ```
@@ -127,9 +127,9 @@ You can use the following helper methods to work with the cache:
 The exists method returns true if the cache key exists, and false otherwise.
 
 ```php
-use App\CacheEntities\CurrentUserCacheEntity;
+use App\CacheEntities\CurrentUserCache;
 
-$cacheEntity = new CurrentUserCacheEntity(1);
+$cacheEntity = new CurrentUserCache(1);
 
 $user = $cacheEntity->get();
 
@@ -145,9 +145,9 @@ if ($cacheEntity->exists()) {
 The doesNotExist method returns true if the cache key does not exist, and false otherwise.
 
 ```php
-use App\CacheEntities\CurrentUserCacheEntity;
+use App\CacheEntities\CurrentUserCache;
 
-$cacheEntity = new CurrentUserCacheEntity(1);
+$cacheEntity = new CurrentUserCache(1);
 
 $user = $cacheEntity->get();
 
@@ -163,11 +163,65 @@ if ($cacheEntity->doesNotExist()) {
 The forget method removes the cache key.
 
 ```php
-use App\CacheEntities\CurrentUserCacheEntity;
+use App\CacheEntities\CurrentUserCache;
 
-$cacheEntity = new CurrentUserCacheEntity(1);
+$cacheEntity = new CurrentUserCache(1);
 
 $user = $cacheEntity->get();
 
 $cacheEntity->forget();
 ```
+
+## Memoization
+
+By default, Cache Entities do not use memoization. However, you can enable it by using the `HasMemoization` trait in your Cache Entity class.
+
+When memoization is enabled, the cache entity will use Laravel's `memo()` method to store the cached value in memory during the request lifecycle. This prevents redundant cache lookups for the same key within a single request, improving performance.
+
+### Enabling Memoization
+
+To enable memoization, simply add the `HasMemoization` trait to your Cache Entity class:
+
+```php
+namespace App\CacheEntities;
+
+use BitMx\CacheEntities\CacheEntity;
+use BitMx\CacheEntities\Traits\HasMemoization;
+use App\Models\User;
+use Carbon\CarbonInterval;
+
+class CurrentUserCache extends CacheEntity
+{
+    use HasMemoization;
+
+    public function __construct(
+        protected int $id,
+    )
+    {
+    }
+
+    protected function resolveKey(): string
+    {
+        return sprintf('current_user:%s', $this->id);
+    }
+
+    protected function resolveTtl(): CarbonInterval
+    {
+        return CarbonInterval::days(12);
+    }
+
+    protected function resolveValue(): mixed
+    {
+        return User::find($this->id);
+    }
+}
+```
+
+With memoization enabled:
+- The first call to `get()` will fetch the value from cache or execute `resolveValue()`
+- Subsequent calls to `get()` within the same request will return the memoized value from memory
+- This avoids redundant cache lookups, improving performance when accessing the same cache entity multiple times
+
+### Without Memoization
+
+If you don't use the `HasMemoization` trait, each call to `get()` will perform a cache lookup, even within the same request.

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -2,6 +2,7 @@ parameters:
     level: 9
     paths:
         - src
+        - tests/phpstan
     checkOctaneCompatibility: true
 
     type_coverage:

--- a/src/CacheEntity.php
+++ b/src/CacheEntity.php
@@ -13,6 +13,11 @@ abstract class CacheEntity implements CacheableEntity
     /** @use HasCacheMethods<TReturn> */
     use HasCacheMethods;
 
+    protected function hasMemoization(): bool
+    {
+        return false;
+    }
+
     public function getKey(): string
     {
         return $this->resolveKey();
@@ -28,11 +33,6 @@ abstract class CacheEntity implements CacheableEntity
     protected function resolveTtl(): \DateInterval|\DateTime|\DateTimeImmutable|int
     {
         return now()->addHour();
-    }
-
-    protected function hasMemoization(): bool
-    {
-        return false;
     }
 
     protected function resolveCacheStore(): ?string

--- a/src/Traits/HasMemoization.php
+++ b/src/Traits/HasMemoization.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace BitMx\CacheEntities\Traits;
+
+trait HasMemoization
+{
+    protected function hasMemoization(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Feature/CacheEntityTest.php
+++ b/tests/Feature/CacheEntityTest.php
@@ -167,7 +167,7 @@ it('does not use memoization when HasMemoization trait is not included', functio
 
     $mockCache = Mockery::mock(Repository::class);
 
-    // Verificar que memo() NO debe ser llamado
+    // Verify that memo() should NOT be called
     $mockCache->shouldNotReceive('memo');
 
     // Pero sí debe llamar directamente a remember()

--- a/tests/Feature/CacheEntityTest.php
+++ b/tests/Feature/CacheEntityTest.php
@@ -170,7 +170,7 @@ it('does not use memoization when HasMemoization trait is not included', functio
     // Verify that memo() should NOT be called
     $mockCache->shouldNotReceive('memo');
 
-    // Pero sí debe llamar directamente a remember()
+    // But should call remember() directly
     $mockCache->shouldReceive('remember')
         ->once()
         ->with('key', 60, Mockery::type('Closure'))

--- a/tests/Feature/CacheEntityTest.php
+++ b/tests/Feature/CacheEntityTest.php
@@ -145,7 +145,7 @@ it('uses memoization when HasMemoization trait is included', function () {
     expect($value)->toBe('value');
 });
 
-it('does not has memoization cache value if hasMemoization HasMemoization trait is not included', function () {
+it('does not use memoization when HasMemoization trait is not included', function () {
     /** @var CacheEntity<string> $entity */
     $entityWithoutMemoization = new class extends CacheEntity
     {

--- a/tests/Feature/CacheEntityTest.php
+++ b/tests/Feature/CacheEntityTest.php
@@ -103,7 +103,7 @@ it('forgets the value', function () {
     expect(Cache::has($entity->getKey()))->toBeFalse();
 });
 
-it('has memoization cache value if hasMemoization HasMemoization trait is included', function () {
+it('uses memoization when HasMemoization trait is included', function () {
     /** @var CacheEntity<string> $entity */
     $entityWithMemoization = new class extends CacheEntity
     {

--- a/tests/phpstan/HasMemoizationStub.php
+++ b/tests/phpstan/HasMemoizationStub.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\PHPStan;
+
+use BitMx\CacheEntities\CacheEntity;
+use BitMx\CacheEntities\Traits\HasMemoization;
+use Carbon\CarbonInterval;
+
+/**
+ * This class exists solely to satisfy PHPStan's trait usage analysis.
+ * It is never instantiated or used in production code.
+ *
+ * @internal
+ *
+ * @extends CacheEntity<null>
+ */
+final class HasMemoizationStub extends CacheEntity
+{
+    use HasMemoization;
+
+    protected function resolveKey(): string
+    {
+        return 'stub';
+    }
+
+    protected function resolveTtl(): CarbonInterval
+    {
+        return CarbonInterval::hour();
+    }
+
+    protected function resolveValue(): mixed
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
Introduces a `HasMemoization` trait to enable in-memory caching of values in cache entities. Updates tests to verify behavior with and without the trait. Adds documentation on enabling and using memoization in cache entities.
